### PR TITLE
Add date-based sorting to feature 0006

### DIFF
--- a/doc/SocialMeli.postman_collection.json
+++ b/doc/SocialMeli.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "6edb6018-55dd-4b88-a7e6-9aca91318dbd",
+		"_postman_id": "df04f1bc-37f5-4d8f-bd28-e6c7bb2f8045",
 		"name": "SocialMeli",
 		"schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json",
-		"_exporter_id": "33853584"
+		"_exporter_id": "34317590"
 	},
 	"item": [
 		{
@@ -425,6 +425,118 @@
 						{
 							"key": "order",
 							"value": "pedro"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "0009 orderAscFeature0006",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:8080/products/followed/1/list?order=date_asc",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"products",
+						"followed",
+						"1",
+						"list"
+					],
+					"query": [
+						{
+							"key": "order",
+							"value": "date_asc"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "0009 orderDescFeature0006",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:8080/products/followed/1/list?order=date_desc",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"products",
+						"followed",
+						"1",
+						"list"
+					],
+					"query": [
+						{
+							"key": "order",
+							"value": "date_desc"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "0009 orderFeature0006 BAD REQUEST",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:8080/products/followed/1/list?order=date_descendente",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"products",
+						"followed",
+						"1",
+						"list"
+					],
+					"query": [
+						{
+							"key": "order",
+							"value": "date_descendente"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "0009 noOrderDescFeature0006",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:8080/products/followed/1/list?order=",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"products",
+						"followed",
+						"1",
+						"list"
+					],
+					"query": [
+						{
+							"key": "order",
+							"value": ""
 						}
 					]
 				}

--- a/src/main/java/org/example/g14/controller/ProductController.java
+++ b/src/main/java/org/example/g14/controller/ProductController.java
@@ -5,12 +5,7 @@ import org.example.g14.service.IPostService;
 import org.example.g14.dto.PostDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -29,8 +24,9 @@ public class ProductController {
     }
 
     @GetMapping("/followed/{user_id}/list")
-    public ResponseEntity<List<PostDto>> getPostsFromFollowed(@PathVariable("user_id") int userId){
-        List<PostDto> posts = postService.getPostsFromFollowed(userId);
+    public ResponseEntity<List<PostDto>> getPostsFromFollowed(@PathVariable("user_id") int userId,
+                                                              @RequestParam(required = false) String order){
+        List<PostDto> posts = postService.getPostsFromFollowed(userId, order);
         return ResponseEntity.ok(posts);
     }
 }

--- a/src/main/java/org/example/g14/service/IPostService.java
+++ b/src/main/java/org/example/g14/service/IPostService.java
@@ -7,6 +7,6 @@ import java.util.List;
 
 public interface IPostService {
     void add(CreatePostDto createPostDto);
-    List<PostDto> getPostsFromFollowed(int userId);
+    List<PostDto> getPostsFromFollowed(int userId, String order);
 
 }


### PR DESCRIPTION
Implements ascending and descending date sorting for the endpoint that lists posts from sellers followed by a user.
Supports two sorting parameters: date_asc for ascending order and date_desc for descending order.
Validates the sorting parameter and returns a 400 Bad Request error for unrecognized values.